### PR TITLE
Avoid specifying WORKING_DIRECTORY twice to fix `cd path;path` error

### DIFF
--- a/components/esp_rust_component/CMakeLists.txt
+++ b/components/esp_rust_component/CMakeLists.txt
@@ -35,7 +35,6 @@ ExternalProject_Add(
         cargo ${RUST_CARGO_TOOLCHAIN} build --release ${CARGO_BUILD_FLAGS} -Zbuild-std-features=compiler-builtins-weak-intrinsics
     BUILD_ALWAYS TRUE
     INSTALL_COMMAND ""
-    WORKING_DIRECTORY ${RUST_PROJECT_DIR}
     TMP_DIR "${RUST_BUILD_DIR}/tmp"
     STAMP_DIR "${RUST_BUILD_DIR}/stamp"
     DOWNLOAD_DIR "${RUST_BUILD_DIR}"


### PR DESCRIPTION
Before removing the `WORKING_DIRECTORY` line, I had an error like this, where the path to `cd` to was duplicated with a semicolon in between.

```
FAILED: esp-idf/80211_mac_rust/stamp/rust_crate_target-install /home/user/Projects/esp32-open-mac/esp32-open-mac/build/esp-idf/80211_mac_rust/stamp/rust_crate_target-install 
cd "/home/user/Projects/esp32-open-mac/esp32-open-mac/components/80211_mac_rust/rust_crate;/home/user/Projects/esp32-open-mac/esp32-open-mac/components/80211_mac_rust/rust_crate" && /usr/bin/cmake -E echo_append
/bin/sh: line 1: cd: /home/user/Projects/esp32-open-mac/esp32-open-mac/components/80211_mac_rust/rust_crate;/home/user/Projects/esp32-open-mac/esp32-open-mac/components/80211_mac_rust/rust_crate: No such file or directory
ninja: build stopped: subcommand failed.
```

Tracing cmake (by adding `--trace-expand` in the cmake command in `idf_py_actions/tools.py`) showed that this is because WORKING_DIRECTORY is specified twice:

```
/usr/share/cmake/Modules/ExternalProject/shared_internal_commands.cmake(277):  _ep_parse_arguments_to_vars(ExternalProject_Add_Step COMMAND;COMMENT;DEPENDEES;DEPENDERS;DEPENDS;INDEPENDENT;BYPRODUCTS;ALWAYS;JOB_SERVER_AWARE;EXCLUDE_FROM_MAIN;WORKING_DIRECTORY;LOG;USES_TERMINAL rust_crate_target _EP_install_ INDEPENDENT;FALSE;COMMAND;WORKING_DIRECTORY;/home/user/Projects/esp32-open-mac/esp32-open-mac/components/80211_mac_rust/rust_crate;BYPRODUCTS;WORKING_DIRECTORY;/home/user/Projects/esp32-open-mac/esp32-open-mac/components/80211_mac_rust/rust_crate;DEPENDEES;build;ALWAYS;1 )
```

With WORKING_DIRECTORY removed, it does now build for me